### PR TITLE
Inject current model state into checkbox

### DIFF
--- a/checkbox/src/main.js
+++ b/checkbox/src/main.js
@@ -8,7 +8,7 @@ function main(sources) {
       .startWith(false)
       .map(toggled =>
         div([
-          input({type: 'checkbox'}), 'Toggle me',
+          input({type: 'checkbox', checked: toggled}), 'Toggle me',
           p(toggled ? 'ON' : 'off')
         ])
       )


### PR DESCRIPTION
Otherwise model state and rendered state may get inconsistent. Try:

```
.startWith(true)
```

Generally, if we have the state at hand, we should explicitly write it to the
input element, IMHO.
